### PR TITLE
Add Cats Effect 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ libraryDependencies += "org.typelevel" %% "scalacheck-effect" % scalacheckEffect
 This project also provides support for checking `PropF` values from within [MUnit](https://scalameta.org/munit/) based test suites. To use scalacheck-effect with munit, add the following dependency to your build:
 
 ```scala
+//Cats Effect 2
 libraryDependencies += "org.typelevel" %% "scalacheck-effect-munit" % scalacheckEffectVersion % Test
+
+//Cats Effect 3
+libraryDependencies += "org.typelevel" %% "scalacheck-effect-munit-ce3" % scalacheckEffectVersion % Test
 ```
 
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ ThisBuild / scmInfo := Some(
 
 lazy val root = project
   .in(file("."))
-  .aggregate(core.jvm, core.js, munit.jvm, munit.js)
+  .aggregate(core.jvm, core.js, munit.jvm, munit.js, munitCE3.jvm, munitCE3.js)
   .enablePlugins(NoPublishPlugin, SonatypeCiReleasePlugin)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)
@@ -67,5 +67,22 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= List(
       "org.scalameta" %%% "munit-scalacheck" % "0.7.22",
       "org.typelevel" %%% "cats-effect" % "2.3.3" % Test
+    )
+  )
+
+lazy val munitCE3 = crossProject(JSPlatform, JVMPlatform)
+  .settings(
+    name := "scalacheck-effect-munit-ce3",
+    testFrameworks += new TestFramework("munit.Framework")
+  )
+  .jsSettings(
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))
+  )
+  .dependsOn(core)
+  .settings(dottyJsSettings(ThisBuild / crossScalaVersions))
+  .settings(
+    libraryDependencies ++= List(
+      "org.scalameta" %%% "munit-scalacheck" % "0.7.22",
+      "org.typelevel" %%% "cats-effect" % "3.0.0-RC2" % Test
     )
   )

--- a/munitCE3/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
+++ b/munitCE3/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import scala.concurrent.Future
+
+import cats.implicits._
+import org.scalacheck.Gen
+import org.scalacheck.effect.PropF
+import org.scalacheck.rng.Seed
+import org.scalacheck.util.Pretty
+
+/** Extends `ScalaCheckSuite`, adding support for evaluation of effectful properties (`PropF[F]` values).
+  *
+  * This trait transforms tests which return `PropF[F]` values in to `F[Unit]` values. The `F[Unit]` values
+  * are transformed to a `Future[Unit]` via `munitValueTransform`. Hence, an appropriate value transform
+  * must be registered for the effect type in use. This is typically done by mixing in an MUnit compatibility
+  * trait for the desired effect type.
+  */
+trait ScalaCheckEffectSuite extends ScalaCheckSuite {
+
+  private val initialSeed: Seed =
+    scalaCheckTestParameters.initialSeed.getOrElse(
+      Seed.fromBase64(scalaCheckInitialSeed).get
+    )
+
+  private val genParameters: Gen.Parameters =
+    Gen.Parameters.default
+      .withLegacyShrinking(scalaCheckTestParameters.useLegacyShrinking)
+      .withInitialSeed(initialSeed)
+
+  override def munitTestTransforms: List[TestTransform] =
+    super.munitTestTransforms :+ scalaCheckPropFTransform
+
+  private val scalaCheckPropFTransform: TestTransform =
+    new TestTransform(
+      "ScalaCheck PropF",
+      t => {
+        t.withBodyMap[TestValue](
+          _.flatMap {
+            case p: PropF[f] =>
+              super.munitValueTransform(checkPropF[f](p)(t.location))
+            case r => Future.successful(r)
+          }(munitExecutionContext)
+        )
+      }
+    )
+
+  private def checkPropF[F[_]](
+      prop: PropF[F]
+  )(implicit loc: Location): F[Unit] = {
+    import prop.F
+    prop.check(scalaCheckTestParameters, genParameters).flatMap { result =>
+      if (result.passed) F.unit
+      else {
+        val seed = genParameters.initialSeed.get
+        val seedMessage = s"""|Failing seed: ${seed.toBase64}
+                              |You can reproduce this failure by adding the following override to your suite:
+                              |
+                              |  override val scalaCheckInitialSeed = "${seed.toBase64}"
+                              |""".stripMargin
+        fail(seedMessage + "\n" + Pretty.pretty(result, scalaCheckPrettyParameters))
+      }
+    }
+  }
+}

--- a/munitCE3/shared/src/test/scala/munit/ExampleCE3.scala
+++ b/munitCE3/shared/src/test/scala/munit/ExampleCE3.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.IO
+import org.scalacheck.effect.PropF
+
+class ExampleCE3 extends ScalaCheckEffectSuite {
+
+  import cats.effect.unsafe.implicits.global
+
+  override def munitValueTransforms: List[ValueTransform] =
+    super.munitValueTransforms ++ List(munitIOTransform)
+
+  // From https://github.com/scalameta/munit/pull/134
+  private val munitIOTransform: ValueTransform =
+    new ValueTransform("IO", { case e: IO[_] => e.unsafeToFuture() })
+
+  test("one") {
+    PropF.forAllNoShrinkF { (a: Int) => IO(assert(a == a)) }
+  }
+
+  test("two") {
+    PropF.forAllF { (a: Int, b: Int) =>
+      IO { assertEquals(a + b, b + a) }
+    }
+  }
+
+  // test("three") {
+  //   forAllAsyncNoShrink(Arbitrary.arbitrary[Int].filter(i => i > 10 && i < 20)) {
+  //     (a: Int) => IO { println(a) }
+  //   }
+  // }
+}


### PR DESCRIPTION
This adds a separate subproject for Cats Effect 3 (RC2) support in Scalacheck Effect. As it turns out, all of the code is presently exactly the same, so there is only one minor difference in the test suite (it needs an IORuntime). Otherwise, it works as-expected.