### PR TITLE
Changed error message to say `def` not `val`

### DIFF
--- a/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
+++ b/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
@@ -64,7 +64,7 @@ trait ScalaCheckEffectSuite extends ScalaCheckSuite {
         val seedMessage = s"""|Failing seed: ${seed.toBase64}
                               |You can reproduce this failure by adding the following override to your suite:
                               |
-                              |  override val scalaCheckInitialSeed = "${seed.toBase64}"
+                              |  override def scalaCheckInitialSeed = "${seed.toBase64}"
                               |""".stripMargin
         fail(seedMessage + "\n" + Pretty.pretty(result, scalaCheckPrettyParameters))
       }


### PR DESCRIPTION
Hello. In the error message it says to declare `override val scalaCheckInitialSeed`, however [`ScalaCheckSuite.scalaCheckInitialSeed`](https://github.com/scalameta/munit/blob/main/munit-scalacheck/shared/src/main/scala/munit/ScalaCheckSuite.scala#L38) declares it as a `def`. As a result declaring it as a `val` was giving me null pointer exceptions, but declaring it as a def worked fine.

This PR amends the message. 