### PR TITLE
Fix example code in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ object Example extends IOApp {
   def run(args: List[String]): IO[ExitCode] = {
     val p: PropF[IO] = 
       PropF.forAllF { (x: Int) =>
-        IO(x).start.flatMap(_.join).map(res => assert(res == x))
+        IO(x).map(res => assert(res == x))
       }
 
     val result: IO[Test.Result] = p.check()


### PR DESCRIPTION
The README example isn't correct after the CE3 upgrade, because the fork and join returns an `Outcome`. (There's a compiler warning noting this.) I'm not sure why the example needs the fork and join, so it is removed which fixes the compilation problem.

Alternatively the example could look like:

```scala
IO(x)
  .background
  .flatMap(_.join)
  .flatMap(res => res.embedNever)
  .map(res => assert(res == x))
```