### PR TITLE
Fix bug where sample sizes would not grow beyond a single element

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/effect/PropF.scala
+++ b/core/shared/src/main/scala/org/scalacheck/effect/PropF.scala
@@ -77,7 +77,7 @@ sealed trait PropF[F[_]] {
   ): F[Test.Result] = {
 
     import testParams.{minSuccessfulTests, minSize, maxDiscardRatio, maxSize}
-    val sizeStep = (maxSize - minSize) / minSuccessfulTests
+    val sizeStep = (maxSize - minSize) / minSuccessfulTests.toDouble
     val maxDiscarded = minSuccessfulTests * maxDiscardRatio
 
     def loop(params: Gen.Parameters, passed: Int, discarded: Int): F[Test.Result] = {
@@ -86,7 +86,8 @@ sealed trait PropF[F[_]] {
       else if (discarded >= maxDiscarded)
         F.pure(Test.Result(Test.Exhausted, passed, discarded, FreqMap.empty))
       else {
-        val size = minSize.toDouble + sizeStep
+        val count = passed + discarded
+        val size = minSize.toDouble + (sizeStep * count)
         checkOne(params.withSize(size.round.toInt)).flatMap { result =>
           result.status match {
             case Prop.True =>


### PR DESCRIPTION
Fixes #136 

The main engine is a port of [the one from scalacheck](https://github.com/typelevel/scalacheck/blob/8e59284cca121aaf4bbed271ddbc9443deef1801/src/main/scala/org/scalacheck/Test.scala#L406-L463), but with a single worker and the while loop turned in to monadic sequencing. I apparently missed multiplying `sizeStep` by `count` as done here (note since we don't currently support parallel workers, we replace that parameter with 1): https://github.com/typelevel/scalacheck/blob/8e59284cca121aaf4bbed271ddbc9443deef1801/src/main/scala/org/scalacheck/Test.scala#L425-L426