### PR TITLE
Extract real exception for munit with Future

### DIFF
--- a/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
+++ b/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
@@ -17,10 +17,18 @@
 package munit
 
 import cats.implicits._
-import org.scalacheck.Gen
+import org.scalacheck.{Gen, Test}
+import org.scalacheck.Test.PropException
 import org.scalacheck.effect.PropF
 import org.scalacheck.rng.Seed
 import org.scalacheck.util.Pretty
+
+import java.lang.reflect.{
+  InvocationTargetException,
+  UndeclaredThrowableException
+}
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionException
 
 /** Extends `ScalaCheckSuite`, adding support for evaluation of effectful properties (`PropF[F]`
   * values).
@@ -57,7 +65,7 @@ trait ScalaCheckEffectSuite extends ScalaCheckSuite {
       prop: PropF[F]
   )(implicit loc: Location): F[Unit] = {
     import prop.F
-    prop.check(scalaCheckTestParameters, genParameters).flatMap { result =>
+    prop.check(scalaCheckTestParameters, genParameters).map(fixResultException).flatMap { result =>
       if (result.passed) F.unit
       else {
         val seed = genParameters.initialSeed.get
@@ -70,4 +78,23 @@ trait ScalaCheckEffectSuite extends ScalaCheckSuite {
       }
     }
   }
+
+  private def fixResultException(result: Test.Result): Test.Result =
+    result.copy(
+      status = result.status match {
+        case p @ PropException(_, e, _) => p.copy(e = rootCause(e))
+        case default                    => default
+      }
+    )
+
+  // https://github.com/scalameta/munit/blob/68c2d13868baec9a77384f11f97505ecc0ce3eba/munit/shared/src/main/scala/munit/MUnitRunner.scala#L318-L326
+  @tailrec
+  private def rootCause(x: Throwable): Throwable = x match {
+    case _: InvocationTargetException | _: ExceptionInInitializerError |
+        _: UndeclaredThrowableException | _: ExecutionException
+        if x.getCause != null =>
+      rootCause(x.getCause)
+    case _ => x
+  }
+
 }

--- a/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
+++ b/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala
@@ -23,10 +23,7 @@ import org.scalacheck.effect.PropF
 import org.scalacheck.rng.Seed
 import org.scalacheck.util.Pretty
 
-import java.lang.reflect.{
-  InvocationTargetException,
-  UndeclaredThrowableException
-}
+import java.lang.reflect.{InvocationTargetException, UndeclaredThrowableException}
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionException
 
@@ -91,8 +88,7 @@ trait ScalaCheckEffectSuite extends ScalaCheckSuite {
   @tailrec
   private def rootCause(x: Throwable): Throwable = x match {
     case _: InvocationTargetException | _: ExceptionInInitializerError |
-        _: UndeclaredThrowableException | _: ExecutionException
-        if x.getCause != null =>
+        _: UndeclaredThrowableException | _: ExecutionException if x.getCause != null =>
       rootCause(x.getCause)
     case _ => x
   }


### PR DESCRIPTION
When using munit exception in Future, these exceptions are additionally wrapped in ExecutionException. That causes test failure to lose its context:

```
==> X munit.Example.three  0.063s munit.FailException: scalacheck-effect\munit\shared\src\main\scala\munit\ScalaCheckEffectSuite.scala:52
51:      { case p: PropF[f] =>
52:        super.munitValueTransform(checkPropF[f](p))
53:      }
Failing seed: _6dy7RwgZvdFcKb-_3Y6drdCAgSpLtmNv3gD0gMvqOJ=
You can reproduce this failure by adding the following override to your suite:

  override def scalaCheckInitialSeed = "_6dy7RwgZvdFcKb-_3Y6drdCAgSpLtmNv3gD0gMvqOJ="

Exception raised on property evaluation.
> ARG_0: 0
> ARG_1: 0
> ARG_0_ORIGINAL: 507884176
> ARG_1_ORIGINAL: 1
> Exception: java.util.concurrent.ExecutionException: Boxed Exception
    at munit.Assertions.fail(Assertions.scala:283)
    at munit.Assertions.fail$(Assertions.scala:277)
    at munit.FunSuite.fail(FunSuite.scala:11)
    at munit.ScalaCheckEffectSuite.$anonfun$checkPropF$1(ScalaCheckEffectSuite.scala:69)
    at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470)
    at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
    at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175)
```

This pull request introduces proper exception extraction just like munit itself does:
```
==> X munit.Example.three  0.078s munit.FailException: scalacheck-effect\munit\shared\src\main\scala\munit\ScalaCheckEffectSuite.scala:60
59:      { case p: PropF[f] =>
60:        super.munitValueTransform(checkPropF[f](p))
61:      }
Failing seed: 2ZteDaQ-7jWeBpOv8dlnj5csn65IF5mqhIJrBwKVbDC=
You can reproduce this failure by adding the following override to your suite:

  override def scalaCheckInitialSeed = "2ZteDaQ-7jWeBpOv8dlnj5csn65IF5mqhIJrBwKVbDC="

Exception raised on property evaluation.
> ARG_0: 0
> ARG_1: 0
> ARG_0_ORIGINAL: -1848315845
> ARG_1_ORIGINAL: -1
> Exception: munit.ComparisonFailException: scalacheck-effect\munit\shared\src\test\scala\munit\Example.scala:47
46:    PropF.forAllF { (a: Int, b: Int) =>
47:      Future { assertEquals(a + b, b + a + 1) }
48:    }
values are not the same
=> Obtained
0
=> Diff (- obtained, + expected)
-0
+1
    at munit.Assertions.fail(Assertions.scala:283)
    at munit.Assertions.fail$(Assertions.scala:277)
    at munit.FunSuite.fail(FunSuite.scala:11)
    at munit.ScalaCheckEffectSuite.$anonfun$checkPropF$2(ScalaCheckEffectSuite.scala:77)
    at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470)
    at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
    at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175)
```