### PR TITLE
Update munit integration example in README file for Cats Effect 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This project also provides support for checking `PropF` values from within [MUni
 ```scala
 libraryDependencies += "org.typelevel" %% "scalacheck-effect-munit" % scalacheckEffectVersion % Test
 ```
+The following usage example is for Cats Effect 2:
 
 ```scala
 import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
@@ -60,6 +61,17 @@ class ExampleSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   }
 }
 ```
+
+For Cats Effect 3, the `join` becomes `joinWithNever`, so the `PropF` in the above example becomes:
+
+```scala
+PropF.forAllF { (x: Int) =>
+  IO(x).start.flatMap(_.joinWithNever).map(res => assert(res == x))
+}
+```
+
+For more details on the differences between Cats Effect 2 and 3 see
+[the Cats Effect 3.x Migration Guide](https://typelevel.org/cats-effect/docs/migration-guide#exitcase-fiber).
 
 ## Design Goals
 


### PR DESCRIPTION
The `join` in Cats Effect 2 is now `joinWithNever` in Cats Effect 3, so the example for using this library with MUnit is updated to show the difference.