### PR TITLE
Custom Arbitrary[Int] to make collisions extremely unlikely

### DIFF
--- a/munit/shared/src/test/scala/munit/ScalaCheckEffectSuiteSuite.scala
+++ b/munit/shared/src/test/scala/munit/ScalaCheckEffectSuiteSuite.scala
@@ -19,7 +19,7 @@ package munit
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.scalacheck.effect.PropF
-import org.scalacheck.Shrink
+import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 // Who tests the tests?
 class ScalaCheckEffectSuiteSuite extends ScalaCheckEffectSuite {
@@ -34,6 +34,10 @@ class ScalaCheckEffectSuiteSuite extends ScalaCheckEffectSuite {
     new ValueTransform("IO", { case e: IO[_] => e.unsafeToFuture() })
 
   test("Correctly slides seed for multi-arg PropF") {
+    implicit val arbForInt: Arbitrary[Int] = Arbitrary(
+      Gen.choose(0, Int.MaxValue)
+    )
+
     var last: Option[Int] = None
     var duplicates = 0
 


### PR DESCRIPTION
Custom `Arbitrary[Int]` to make collisions extremely unlikely. We believe that the default `Arbitarary[Int]`'s bias towards small values was making [tests fail](https://github.com/typelevel/scalacheck-effect/actions/runs/8115441556/job/22183314113?pr=331).

Test output saved for posterity:
```
munit.ScalaCheckEffectSuiteSuite:
==> X munit.ScalaCheckEffectSuiteSuite.Correctly slides seed for multi-arg PropF  0.494s munit.FailException: /home/runner/work/scalacheck-effect/scalacheck-effect/munit/shared/src/main/scala/munit/ScalaCheckEffectSuite.scala:62
61:      { case p: PropF[f] =>
62:        super.munitValueTransform(checkPropF[f](p))
63:      }
Failing seed: QRNvpBYUvcWdebEZ0LePM_-Fe0Sb7IpJWfnWwSPTqWA=
You can reproduce this failure by adding the following override to your suite:

  override def scalaCheckInitialSeed = "QRNvpBYUvcWdebEZ0LePM_-Fe0Sb7IpJWfnWwSPTqWA="

Exception raised on property evaluation.
> ARG_0: 2147483647
> ARG_1: -2147483648
> Exception: munit.FailException: /home/runner/work/scalacheck-effect/scalacheck-effect/munit/shared/src/test/scala/munit/ScalaCheckEffectSuiteSuite.scala:49 assertion failed
48:      // generated value from the previous iteration
49:      IO { assert(clue(duplicates) < 10) }
50:    }
Clues {
  duplicates: Int = 10
}
```