### PR TITLE
Adding a Boolean test transformer

### DIFF
--- a/core/shared/src/main/scala/org/scalacheck/effect/PropF.scala
+++ b/core/shared/src/main/scala/org/scalacheck/effect/PropF.scala
@@ -197,6 +197,11 @@ object PropF {
         .handleError(t => Result[F](Prop.Exception(t), Nil, Set.empty, Set.empty))
     )
 
+  implicit def effectOfBooleanToPropF[F[_]](
+      fb: F[Boolean]
+  )(implicit F: MonadError[F, Throwable]): PropF[F] =
+    effectOfPropFToPropF(F.map(fb)(boolean(_)))
+
   def forAllNoShrinkF[F[_], T1, P](
       g1: Gen[T1]
   )(

--- a/munit/shared/src/test/scala/munit/Example.scala
+++ b/munit/shared/src/test/scala/munit/Example.scala
@@ -35,6 +35,10 @@ class Example extends ScalaCheckEffectSuite {
     PropF.forAllNoShrinkF { (a: Int) => IO(assert(a == a)) }
   }
 
+  test("one-alt") {
+    PropF.forAllNoShrinkF { (a: Int) => IO(a == a) }
+  }
+
   test("two") {
     PropF.forAllF { (a: Int, b: Int) =>
       IO { assertEquals(a + b, b + a) }


### PR DESCRIPTION
Solves #25. Thanks to @adrian-salajan for the implementation.

P.S. The implementation could have been more barebone, like 

```scala
  implicit def effectOfBooleanToPropF[F[_]](
      fu: F[Unit]
  )(implicit F: MonadError[F, Throwable]): PropF[F] =
    Suspend[F, Result[F]](
      fu.map(boolean(_))
        .handleError(t => Result[F](Prop.Exception(t), Nil, Set.empty, Set.empty))
    )
```

or similar, is this preferrable?