### PR TITLE
bump munit-scalacheck

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .dependsOn(core)
   .settings(
     libraryDependencies ++= List(
-      "org.scalameta" %%% "munit-scalacheck" % "1.0.0-M11",
+      "org.scalameta" %%% "munit-scalacheck" % "1.0.0",
       "org.typelevel" %%% "cats-effect" % "3.5.4" % Test
     )
   )


### PR DESCRIPTION
I don't know why steward didn't open a PR for this bump? It just says [scalacheck-effect is up-to-date](https://github.com/typelevel/steward/actions/runs/9207627634/job/25328100888#step:5:1991).

Anyway, proposing that we bump to 1.0 now that it's released (🎉). Could we then release a full v2.0.0 of scalacheck-effect (assuming tests pass okay), or is there other work to do first?