### PR TITLE
Add an Arbitrary[Random[F]] instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p munit/jvm/target core/native/target core/js/target munit/native/target core/jvm/target munit/js/target project/target
+        run: mkdir -p cats-effect/native/target munit/jvm/target core/native/target cats-effect/jvm/target core/js/target munit/native/target core/jvm/target cats-effect/js/target munit/js/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar munit/jvm/target core/native/target core/js/target munit/native/target core/jvm/target munit/js/target project/target
+        run: tar cf targets.tar cats-effect/native/target munit/jvm/target core/native/target cats-effect/jvm/target core/js/target munit/native/target core/jvm/target cats-effect/js/target munit/js/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / startYear := Some(2021)
 ThisBuild / crossScalaVersions := List("3.3.3", "2.12.19", "2.13.14")
 ThisBuild / tlVersionIntroduced := Map("3" -> "1.0.2")
 
-lazy val root = tlCrossRootProject.aggregate(core, munit)
+lazy val root = tlCrossRootProject.aggregate(core, `cats-effect`, munit)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
@@ -19,6 +19,15 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.typelevel" %%% "cats-core" % "2.11.0"
     )
   )
+
+lazy val `cats-effect` = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .settings(
+    name := "scalacheck-cats-effect",
+    libraryDependencies ++= List(
+      "org.typelevel" %%% "cats-effect" % "3.5.4"
+    )
+  )
+  .dependsOn(core)
 
 lazy val munit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(

--- a/cats-effect/shared/src/main/scala/cats/effect/std/ArbitraryRandom.scala
+++ b/cats-effect/shared/src/main/scala/cats/effect/std/ArbitraryRandom.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats.effect.std
+
+import cats.effect.*
+import cats.effect.std.Random.ScalaRandom
+import cats.syntax.all.*
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+
+trait ArbitraryRandom {
+
+  /** Generates a `Random[F]` instance seeded by a generated long value, so that the "randomness"
+    * will be repeatable given the same ScalaCheck seed.
+    */
+  def genRandom[F[_]: Sync]: Gen[Random[F]] =
+    Gen.long
+      .map(new scala.util.Random(_).pure[F])
+      .map(new ScalaRandom[F](_) {})
+
+  implicit def arbRandom[F[_]: Sync]: Arbitrary[Random[F]] = Arbitrary(genRandom[F])
+
+  implicit def shrinkRandom[F[_]]: Shrink[Random[F]] = Shrink.shrinkAny
+}
+
+object ArbitraryRandom extends ArbitraryRandom


### PR DESCRIPTION
This will link the randomness used by the code under test to ScalaCheck's seed, which should improve test repeatability.

I didn't see a good place to introduce this instance; previously users would have to use both `scalacheck-effect-munit` and `munit-cats-effect` to run `IO`-based property tests. This introduces a new artifact that depends on both ScalaCheck and Cats Effect in order to make the instance available.